### PR TITLE
Option in configuration to set a custom route prefix

### DIFF
--- a/Core/CoreAdmin.php
+++ b/Core/CoreAdmin.php
@@ -163,11 +163,11 @@ class CoreAdmin implements ContainerAwareInterface
 			}
 		}
 
-
-		$method = lcfirst(str_replace('_', '', ucwords($action, '_')));
+        $routePrefix = $this->container->getParameter('sfs_admin.routes_prefix');
+        $method = lcfirst(str_replace('_', '', ucwords($action, '_')));
 
 		$this->routes[$slug][$action] = array(
-			'route'				=> 'sfs_admin_'. $slug .'_'. $action,
+			'route'				=> $routePrefix .'_'. $slug .'_'. $action,
 			'action'			=> $method .'Action',
 			'path'				=> $path,
 			'requirements'		=> $requirements,

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -61,8 +61,9 @@ class Configuration implements ConfigurationInterface
 					->end()
 				->end()
 			->end()
-			->scalarNode('title_text')->defaultValue('Sfs Admin')->end()
-			->scalarNode('title_logo')->defaultNull()->end()
+            ->scalarNode('routes_prefix')->defaultValue('sfs_admin')->end()
+            ->scalarNode('title_text')->defaultValue('Sfs Admin')->end()
+            ->scalarNode('title_logo')->defaultNull()->end()
 		->end();
 
 		return $treeBuilder;

--- a/DependencyInjection/SfsAdminExtension.php
+++ b/DependencyInjection/SfsAdminExtension.php
@@ -32,6 +32,7 @@ class SfsAdminExtension extends Extension implements PrependExtensionInterface
         $container->setParameter('sfs_admin.menu_categories', $config['menu_categories']);
         $container->setParameter('sfs_admin.pages', $config['pages']);
         $container->setParameter('sfs_admin.topbar_buttons', $config['topbar_buttons']);
+        $container->setParameter('sfs_admin.routes_prefix', $config['routes_prefix']);
         $container->setParameter('sfs_admin.title_text', $config['title_text']);
         $container->setParameter('sfs_admin.title_logo', $config['title_logo']);
 


### PR DESCRIPTION
We can now use the configuration sfs_admin.routes_prefix to override the default routing prefix 'sfs_admin'